### PR TITLE
Add boeing data to timetrend tab

### DIFF
--- a/DashMonitor/app/data/analyzers/__init__.py
+++ b/DashMonitor/app/data/analyzers/__init__.py
@@ -8,3 +8,4 @@ from DashMonitor.app.data.analyzers.general_analyzer import (
     GeneralComparisonAnalyzer,
 )
 from DashMonitor.app.data.analyzers.sasb_analyzer import SASBAnalyzer
+from DashMonitor.app.data.analyzers.time_trend_analyzer import TimeTrendAnalyzer

--- a/DashMonitor/app/data/analyzers/time_trend_analyzer.py
+++ b/DashMonitor/app/data/analyzers/time_trend_analyzer.py
@@ -56,6 +56,11 @@ class TimeTrendAnalyzer(BaseAnalyzer):
         res = df[df["bank_name"] == bank_name]["total_sentiment_score"].mean()
 
         return 0 if np_isnan(res) else round(res)
+    
+    def get_all_reviews_by_company(self, bank_name):
+        df = self.__data_analyzed
+
+        return df[df["bank_name"] == bank_name]
 
     def execute(self):
         super().execute()

--- a/DashMonitor/app/data/analyzers/time_trend_analyzer.py
+++ b/DashMonitor/app/data/analyzers/time_trend_analyzer.py
@@ -1,0 +1,63 @@
+'''
+Time Trend Analysis for Dataframe
+'''
+
+from DashMonitor.app.data.analyzers.base_analyzer import BaseAnalyzer
+from numpy import isnan as np_isnan
+from pandas import Categorical as pd_Categorical, DataFrame as pd_DataFrame
+import pandas as pd
+
+
+class TimeTrendAnalyzer(BaseAnalyzer):
+    '''
+    TimeTrendAnalyzer generates all analysis related to Time Trend Tab Specifically.
+    '''
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.__data_analyzed = self._BaseAnalyzer__provider()
+
+    def _filter(self):
+        pass
+
+    def _group(self):
+        df = self.__data_analyzed
+
+        self.__data_analyzed = (
+            df.groupby(["bank_name", "predicted_pilar", "year", "month_num", "date"])[
+                ["sentiment_score"]
+            ]
+            .mean()
+            .reset_index()
+        )
+
+    def _aggregate(self):
+        df = self.__data_analyzed
+
+        df["total_sentiment_score"] = df.groupby(["bank_name", "date"])[
+            "sentiment_score"
+        ].transform("mean")
+
+    def _having(self): ...
+
+    def _sort(self):
+        self.__data_analyzed.sort_values("date", inplace=True)
+
+    def _transform(self):
+        df = self.__data_analyzed
+        self.__data_analyzed["date"] = pd.to_datetime(df["year"].astype(str) + "-" + df["month_num"].map("{:02}".format), format="%Y-%m")
+
+    def size(self) -> tuple:
+        return (self.__data_analyzed.shape[0], self.__data_analyzed.shape[1])
+
+    def general_score(self, bank_name):
+        df = self.__data_analyzed
+
+        res = df[df["bank_name"] == bank_name]["total_sentiment_score"].mean()
+
+        return 0 if np_isnan(res) else round(res)
+
+    def execute(self):
+        super().execute()
+
+        return self.__data_analyzed

--- a/DashMonitor/app/views/layouts/benchmark_analysis.py
+++ b/DashMonitor/app/views/layouts/benchmark_analysis.py
@@ -20,6 +20,7 @@ from DashMonitor.app.handlers.function_utils import (
     create_result_table,
     create_gauge_chart,
     create_gauge_chart_ssindex,
+    categorize_score_to_text_class_name
 )
 
 from DashMonitor.app.views import components as cpt
@@ -28,12 +29,15 @@ from DashMonitor.app.views import components as cpt
 from DashMonitor.app.views.layouts.mock_data_sasb_analysis import *
 from DashMonitor.app.views.configs import (
     main_df_provider,
+    COMPANY_NAME,
 )
 
 
 analyzer = TimeTrendAnalyzer(
     main_df_provider, None
 )
+
+reviews_data = analyzer.get_all_reviews_by_company(COMPANY_NAME)
 
 data_frame = analyzer.execute()
 
@@ -75,6 +79,22 @@ data = [
 
 df = data_frame
 # Your imports and code...
+html_data = [
+    {
+        "data": [
+            html.P(row["review"]),
+            html.P(className=f"{categorize_score_to_text_class_name(row['sentiment_score'])}", children=f"{row['sentiment_score']}%"),
+            html.P(className=f"{categorize_score_to_text_class_name(row['sentiment_score'])}", children=f"{categorize_score(row['sentiment_score'])}"),
+            html.P(row['pilar']),
+            html.P(row['dimension_sasb']),
+            html.P(row['state']),
+            html.P(row['state']),
+            html.P(row['ds']),
+            html.P(row['data_source'])
+        ]
+    }
+    for _, row in reviews_data.iterrows()
+]
 
 BENCHMARK_ANALYSIS_LAYOUT = html.Div(
     className="container",
@@ -104,7 +124,7 @@ BENCHMARK_ANALYSIS_LAYOUT = html.Div(
             children=[
                 cpt.Table(
                     headers=nested_headers,
-                    data=data,
+                    data=html_data,
                     class_name_div="table-ssindex-nested-table-background text-center rounded-3",
                     class_name_table="table table-borderless table-responsive table-ssindex-nested-table-background rounded rounded-3",
                     class_name_headers="text-center table-white align-middle",

--- a/DashMonitor/app/views/layouts/benchmark_analysis.py
+++ b/DashMonitor/app/views/layouts/benchmark_analysis.py
@@ -14,6 +14,7 @@ import dash_bootstrap_components as dbc
 from dash import html
 
 # local imports
+from DashMonitor.app.data.analyzers import TimeTrendAnalyzer
 from DashMonitor.app.handlers.function_utils import (
     categorize_score,
     create_result_table,
@@ -25,6 +26,16 @@ from DashMonitor.app.views import components as cpt
 
 # Import mock data
 from DashMonitor.app.views.layouts.mock_data_sasb_analysis import *
+from DashMonitor.app.views.configs import (
+    main_df_provider,
+)
+
+
+analyzer = TimeTrendAnalyzer(
+    main_df_provider, None
+)
+
+data_frame = analyzer.execute()
 
 category_order = ["Universe", "Industry", "Company"]
 custom_colors = {
@@ -62,6 +73,7 @@ data = [
     {"data": nested_data[2]},
 ]
 
+df = data_frame
 # Your imports and code...
 
 BENCHMARK_ANALYSIS_LAYOUT = html.Div(
@@ -149,28 +161,28 @@ BENCHMARK_ANALYSIS_LAYOUT = html.Div(
                                             options=[
                                                 {"label": pilar, "value": pilar}
                                                 for pilar in df[
-                                                    "Predicted_Pilar"
+                                                    "predicted_pilar"
                                                 ].unique()
                                             ],
-                                            value=df["Predicted_Pilar"].unique()[0],
+                                            value=df["predicted_pilar"].unique()[0],
                                             clearable=False,
                                         ),
                                         dcc.Dropdown(
                                             id="bank-dropdown",
                                             options=[
                                                 {"label": bank, "value": bank}
-                                                for bank in df["Bank Name"].unique()
+                                                for bank in df["bank_name"].unique()
                                             ],
-                                            value=df["Bank Name"].unique()[2],
+                                            value=df["bank_name"].unique()[0],
                                             clearable=False,
                                         ),
                                         dcc.Checklist(
                                             id="bank-checklist",
                                             options=[
                                                 {"label": name, "value": name}
-                                                for name in df["Bank Name"].unique()
+                                                for name in df["bank_name"].unique()
                                             ],
-                                            value=["Webster Bank"],
+                                            value=["Boeing"],
                                             inline=False,
                                             style={
                                                 "display": "flex",
@@ -206,15 +218,15 @@ def register_callbacks(app):
     def update_graphs(selected_year, selected_pilar, selected_banks):
         filtered_df = df[
             (df["year"] == selected_year)
-            & (df["Predicted_Pilar"] == selected_pilar)
-            & (df["Bank Name"].isin(selected_banks))
+            & (df["predicted_pilar"] == selected_pilar)
+            & (df["bank_name"].isin(selected_banks))
         ]
 
         yearly_pilar_line_fig = px.line(
             filtered_df,
             x="date",
-            y="Normalized_Sentiment_Score",
-            color="Bank Name",
+            y="sentiment_score",
+            color="bank_name",
             title=f"Sentiment Score for {selected_year} - {selected_pilar}",
         )
         yearly_pilar_line_fig.update_layout(
@@ -225,8 +237,8 @@ def register_callbacks(app):
         total_score_line_fig = px.line(
             filtered_df,
             x="date",
-            y="Total_Sentiment_Score",
-            color="Bank Name",
+            y="total_sentiment_score",
+            color="bank_name",
             title=f"Total Sentiment Score for {selected_year}",
         )
         total_score_line_fig.update_layout(
@@ -235,16 +247,16 @@ def register_callbacks(app):
             yaxis=dict(showgrid=True),
         )
         overall_df = (
-            df[df["Bank Name"].isin(selected_banks)]
-            .groupby(["Bank Name", "date"])
-            .agg({"Total_Sentiment_Score": "mean"})
+            df[df["bank_name"].isin(selected_banks)]
+            .groupby(["bank_name", "date"])
+            .agg({"total_sentiment_score": "mean"})
             .reset_index()
         )
         overall_time_line_fig = px.line(
             overall_df,
             x="date",
-            y="Total_Sentiment_Score",
-            color="Bank Name",
+            y="total_sentiment_score",
+            color="bank_name",
         )
 
         overall_time_line_fig.update_layout(
@@ -268,7 +280,7 @@ def register_callbacks(app):
                                     }
                                 }
                             ],
-                            "label": "1 Semana",
+                            "label": "1 Week",
                             "method": "relayout",
                         },
                         {
@@ -285,7 +297,7 @@ def register_callbacks(app):
                                     }
                                 }
                             ],
-                            "label": "1 Mes",
+                            "label": "1 Month",
                             "method": "relayout",
                         },
                         {
@@ -302,7 +314,7 @@ def register_callbacks(app):
                                     }
                                 }
                             ],
-                            "label": "6 Meses",
+                            "label": "6 Months",
                             "method": "relayout",
                         },
                         {
@@ -319,7 +331,7 @@ def register_callbacks(app):
                                     }
                                 }
                             ],
-                            "label": "1 Año",
+                            "label": "1 Year",
                             "method": "relayout",
                         },
                         {
@@ -336,7 +348,7 @@ def register_callbacks(app):
                                     }
                                 }
                             ],
-                            "label": "3 Años",
+                            "label": "3 Years",
                             "method": "relayout",
                         },
                         {
@@ -352,7 +364,7 @@ def register_callbacks(app):
                                     }
                                 }
                             ],
-                            "label": "Toda la historia",
+                            "label": "All history",
                             "method": "relayout",
                         },
                     ],
@@ -378,9 +390,9 @@ def register_callbacks(app):
         )
         boxplot_fig = px.box(
             filtered_df,
-            x="Bank Name",
-            y="Normalized_Sentiment_Score",
-            color="Bank Name",
+            x="bank_name",
+            y="sentiment_score",
+            color="bank_name",
         )
 
         boxplot_fig.update_layout(


### PR DESCRIPTION
### Summary
- Tab time trend: Se agrego la data de boeing a la pestaña.

### Files changed
M       DashMonitor/app/data/analyzers/__init__.py
A       DashMonitor/app/data/analyzers/time_trend_analyzer.py
M       DashMonitor/app/views/layouts/benchmark_analysis.py
### Source branch
`feature/add-timetrend-layout`