### PR TITLE
Add disabled datepicker and connect with timetrend graph

### DIFF
--- a/DashMonitor/app/views/components/date_picker/callbacks.py
+++ b/DashMonitor/app/views/components/date_picker/callbacks.py
@@ -3,21 +3,6 @@ from datetime import date, timedelta
 from DashMonitor.app.views.components.date_picker.date_picker import DatePicker
 
 
-def calculate_date_range(selected_index: int) -> str:
-    '''Calculate date range based on selected button.'''
-    today = date.today()
-    # Today button selected
-    if selected_index == 0:
-        return f"{today}"
-    # Custom range selected from DATE_RANGES
-    if selected_index in range(1, 6):
-        start_date = today - timedelta(days=DatePicker.DATE_RANGES[selected_index - 1])
-        return f"{start_date} - {today}"
-
-    # Default label if no range is selected
-    return f"{today - timedelta(days=365)} - {today}"
-
-
 def register_datepicker_callbacks(app):
 
     @app.callback(
@@ -38,16 +23,13 @@ def register_datepicker_callbacks(app):
             return f'{start_date} - {end_date}' if end_date else f'{start_date}'
 
         # Predefined button selected
-        selected_index = next(
-            (
-                i
-                for i, class_name in enumerate(button_classes)
-                if DatePicker.STYLE_SELECTED_BUTTON in class_name
-            ),
-            None,
-        )
-        # Calculate date range based on selected button
-        return calculate_date_range(selected_index)
+        selected_index = DatePicker.selected_button_index(button_classes)
+        # Calculate start date based on selected button
+        start_date = DatePicker.calculate_start_date(selected_index)
+        today = date.today()
+        if selected_index == 0:
+            return f'{today}'
+        return f'{start_date} - {today}'
 
     @app.callback(
         [Output(btn_id, 'className') for btn_id in DatePicker.BUTTON_IDS],

--- a/DashMonitor/app/views/components/date_picker/date_picker.py
+++ b/DashMonitor/app/views/components/date_picker/date_picker.py
@@ -7,6 +7,11 @@ class DatePicker(BaseComponent):
     '''
     Date Picker Component. Generates a date picker component which allows the user to select a date
     and predefined ranges like 'Today', '5 days', etc.
+
+    Parameters
+    ----------
+    disabled : bool
+        If True, the Date Picker is disabled and cannot be interacted with. Default is False.
     '''
 
     # Constants for labels and button IDs
@@ -18,7 +23,22 @@ class DatePicker(BaseComponent):
     STYLE_SELECTED_BUTTON = 'btn btn-primary m-1'
     STYLE_UNSELECTED_BUTTON = 'btn btn-outline-primary m-1'
 
+    def __init__(self, disabled=False):
+        self.disabled = disabled
+
     def render(self):
+        # Determine the button classes and attributes based on the disabled state
+        button_class = (
+            'btn m-1 ms-2 border border-dark text-ssindex-graph-grey'
+            if not self.disabled
+            else 'btn m-1 ms-2 text-ssindex-graph-grey border border-0'
+        )
+
+        button_attributes = {
+            'data-bs-toggle': 'collapse',
+            'data-bs-target': '#date-picker-container',
+        } if not self.disabled else {}
+
         return html.Div(
             children=[
                 html.Label('Time Frame', className='form-label'),
@@ -26,13 +46,11 @@ class DatePicker(BaseComponent):
                 html.Button(
                     children=f'{date.today() - timedelta(days=365)} - {date.today()}',
                     id='date-picker-button',
-                    className='btn m-1 ms-2 border border-dark text-ssindex-graph-grey',
-                    **{
-                        'data-bs-toggle': 'collapse',
-                        'data-bs-target': '#date-picker-container',
-                    },
+                    className=button_class,
+                    disabled=self.disabled,
+                    **button_attributes,
                 ),
-                # Collapsible container for Date Picker
+                # Collapsible container for Date Picker (only renders if not disabled)
                 html.Div(
                     id='date-picker-container',
                     className='collapse z-3 position-absolute bg-white border rounded shadow-lg w-25',
@@ -86,6 +104,6 @@ class DatePicker(BaseComponent):
                             ],
                         )
                     ],
-                ),
+                ) if not self.disabled else None,
             ]
         )

--- a/DashMonitor/app/views/components/date_picker/date_picker.py
+++ b/DashMonitor/app/views/components/date_picker/date_picker.py
@@ -17,7 +17,7 @@ class DatePicker(BaseComponent):
     # Constants for labels and button IDs
     BUTTON_LABELS = ['Today', '5 days', '1 month', '3 months', '6 months', '1 year']
     BUTTON_IDS = [f'btn-nclicks-{i}' for i in range(len(BUTTON_LABELS))]
-    DATE_RANGES = [5, 30, 90, 180, 365]  # Corresponding ranges
+    DATE_RANGES = [5, 30, 91, 182, 365]  # Corresponding ranges
 
     # Styles for predefined ranges buttons
     STYLE_SELECTED_BUTTON = 'btn btn-primary m-1'

--- a/DashMonitor/app/views/components/date_picker/date_picker.py
+++ b/DashMonitor/app/views/components/date_picker/date_picker.py
@@ -31,7 +31,7 @@ class DatePicker(BaseComponent):
         button_class = (
             'btn m-1 ms-2 border border-dark text-ssindex-graph-grey'
             if not self.disabled
-            else 'btn m-1 ms-2 text-ssindex-graph-grey border border-0'
+            else 'btn m-1 ms-1 text-ssindex-graph-grey border border-0'
         )
 
         button_attributes = {
@@ -45,7 +45,7 @@ class DatePicker(BaseComponent):
                 # Button to open DatePicker, initially shows the last year date range
                 html.Button(
                     children=f'{date.today() - timedelta(days=365)} - {date.today()}',
-                    id='date-picker-button',
+                    id='date-picker-button' if not self.disabled else '',
                     className=button_class,
                     disabled=self.disabled,
                     **button_attributes,

--- a/DashMonitor/app/views/components/date_picker/date_picker.py
+++ b/DashMonitor/app/views/components/date_picker/date_picker.py
@@ -17,7 +17,7 @@ class DatePicker(BaseComponent):
     # Constants for labels and button IDs
     BUTTON_LABELS = ['Today', '5 days', '1 month', '3 months', '6 months', '1 year']
     BUTTON_IDS = [f'btn-nclicks-{i}' for i in range(len(BUTTON_LABELS))]
-    DATE_RANGES = [5, 30, 91, 182, 365]  # Corresponding ranges
+    DATE_RANGES = [0, 5, 30, 91, 182, 365]  # Corresponding ranges
 
     # Styles for predefined ranges buttons
     STYLE_SELECTED_BUTTON = 'btn btn-primary m-1'
@@ -26,6 +26,27 @@ class DatePicker(BaseComponent):
     def __init__(self, disabled=False):
         self.disabled = disabled
 
+    def selected_button_index(button_classes: list) -> int:
+        '''Get the index of the selected button.'''
+        return next(
+            (
+                i
+                for i, class_name in enumerate(button_classes)
+                if DatePicker.STYLE_SELECTED_BUTTON in class_name
+            ),
+            None,
+        )
+
+    def calculate_start_date(selected_index: int) -> str:
+        '''Calculate start date based on selected button.'''
+        today = date.today()
+        for index in range(0, len(DatePicker.DATE_RANGES) + 1):
+            if selected_index == index:
+                return today - timedelta(days=DatePicker.DATE_RANGES[index])
+
+        # Default start date is 1 year ago if no button is selected
+        return today - timedelta(days=365)
+
     def render(self):
         # Determine the button classes and attributes based on the disabled state
         button_class = (
@@ -33,11 +54,6 @@ class DatePicker(BaseComponent):
             if not self.disabled
             else 'btn m-1 ms-1 text-ssindex-graph-grey border border-0'
         )
-
-        button_attributes = {
-            'data-bs-toggle': 'collapse',
-            'data-bs-target': '#date-picker-container',
-        } if not self.disabled else {}
 
         return html.Div(
             children=[
@@ -48,62 +64,70 @@ class DatePicker(BaseComponent):
                     id='date-picker-button' if not self.disabled else '',
                     className=button_class,
                     disabled=self.disabled,
-                    **button_attributes,
+                    **{
+                        'data-bs-toggle': 'collapse',
+                        'data-bs-target': '#date-picker-container',
+                    },
                 ),
                 # Collapsible container for Date Picker (only renders if not disabled)
-                html.Div(
-                    id='date-picker-container',
-                    className='collapse z-3 position-absolute bg-white border rounded shadow-lg w-25',
-                    children=[
-                        html.Div(
-                            className='d-flex flex-column mt-4 mb-3 p-1',
-                            children=[
-                                html.Div(
-                                    className='mb-2',
-                                    children=[
-                                        # Buttons for predefined date ranges
-                                        html.Div(
-                                            className='text-center',
-                                            children=[
-                                                html.Button(
-                                                    label,
-                                                    type='button',
-                                                    className=DatePicker.STYLE_UNSELECTED_BUTTON,
-                                                    id=btn_id,
-                                                    n_clicks=0,
-                                                )
-                                                for label, btn_id in zip(
-                                                    self.BUTTON_LABELS, self.BUTTON_IDS
-                                                )
-                                            ],
-                                        ),
-                                    ],
-                                ),
-                                # Calendar Date Picker
-                                html.Div(
-                                    className='text-center',
-                                    children=[
-                                        dcc.DatePickerRange(
-                                            id='date-picker-range',
-                                            clearable=True,
-                                        ),
-                                    ],
-                                ),
-                                # Submit Filter Button
-                                html.Div(
-                                    className='text-center mt-3',
-                                    children=[
-                                        html.Button(
-                                            'Search',
-                                            className='btn btn-success m-1',
-                                            id='submit-btn',
-                                            n_clicks=0,
-                                        )
-                                    ],
-                                ),
-                            ],
-                        )
-                    ],
-                ) if not self.disabled else None,
+                (
+                    html.Div(
+                        id='date-picker-container',
+                        className='collapse z-3 position-absolute bg-white border rounded shadow-lg w-25',
+                        children=[
+                            html.Div(
+                                className='d-flex flex-column mt-4 mb-3 p-1',
+                                children=[
+                                    html.Div(
+                                        className='mb-2',
+                                        children=[
+                                            # Buttons for predefined date ranges
+                                            html.Div(
+                                                className='text-center',
+                                                children=[
+                                                    html.Button(
+                                                        label,
+                                                        type='button',
+                                                        className=DatePicker.STYLE_UNSELECTED_BUTTON,
+                                                        id=btn_id,
+                                                        n_clicks=0,
+                                                    )
+                                                    for label, btn_id in zip(
+                                                        self.BUTTON_LABELS,
+                                                        self.BUTTON_IDS,
+                                                    )
+                                                ],
+                                            ),
+                                        ],
+                                    ),
+                                    # Calendar Date Picker
+                                    html.Div(
+                                        className='text-center',
+                                        children=[
+                                            dcc.DatePickerRange(
+                                                id='date-picker-range',
+                                                clearable=True,
+                                            ),
+                                        ],
+                                    ),
+                                    # Submit Filter Button
+                                    html.Div(
+                                        className='text-center mt-3',
+                                        children=[
+                                            html.Button(
+                                                'Search',
+                                                className='btn btn-success m-1',
+                                                id='submit-btn',
+                                                n_clicks=0,
+                                            )
+                                        ],
+                                    ),
+                                ],
+                            )
+                        ],
+                    )
+                    if not self.disabled
+                    else None
+                ),
             ]
         )

--- a/DashMonitor/app/views/components/date_picker/date_picker.py
+++ b/DashMonitor/app/views/components/date_picker/date_picker.py
@@ -26,6 +26,7 @@ class DatePicker(BaseComponent):
     def __init__(self, disabled=False):
         self.disabled = disabled
 
+    @staticmethod
     def selected_button_index(button_classes: list) -> int:
         '''Get the index of the selected button.'''
         return next(
@@ -37,6 +38,7 @@ class DatePicker(BaseComponent):
             None,
         )
 
+    @staticmethod
     def calculate_start_date(selected_index: int) -> str:
         '''Calculate start date based on selected button.'''
         today = date.today()

--- a/DashMonitor/app/views/layouts/benchmark_analysis.py
+++ b/DashMonitor/app/views/layouts/benchmark_analysis.py
@@ -3,12 +3,12 @@ BENCHMARK Analysis Layout
 """
 
 # std imports
+from datetime import date
 import plotly.express as px
 import pandas as pd
-import numpy as np
 import plotly.graph_objects as go
-from dash import Dash, html, dcc, Input, Output, State, dash_table
-import dash_bootstrap_components as dbc
+from dash import html, dcc, Input, Output, State
+
 
 # 3rd party imports
 from dash import html
@@ -17,15 +17,16 @@ from dash import html
 from DashMonitor.app.data.analyzers import TimeTrendAnalyzer
 from DashMonitor.app.handlers.function_utils import (
     categorize_score,
-    create_result_table,
-    create_gauge_chart,
-    create_gauge_chart_ssindex,
-    categorize_score_to_text_class_name
+    categorize_score_to_text_class_name,
 )
 
 from DashMonitor.app.views import components as cpt
 
 # Import mock data
+from DashMonitor.app.views.components.date_picker.callbacks import (
+    register_datepicker_callbacks,
+)
+from DashMonitor.app.views.components.date_picker.date_picker import DatePicker
 from DashMonitor.app.views.layouts.mock_data_sasb_analysis import *
 from DashMonitor.app.views.configs import (
     main_df_provider,
@@ -33,9 +34,7 @@ from DashMonitor.app.views.configs import (
 )
 
 
-analyzer = TimeTrendAnalyzer(
-    main_df_provider, None
-)
+analyzer = TimeTrendAnalyzer(main_df_provider, None)
 
 reviews_data = analyzer.get_all_reviews_by_company(COMPANY_NAME)
 
@@ -83,14 +82,20 @@ html_data = [
     {
         "data": [
             html.P(row["review"]),
-            html.P(className=f"{categorize_score_to_text_class_name(row['sentiment_score'])}", children=f"{row['sentiment_score']}%"),
-            html.P(className=f"{categorize_score_to_text_class_name(row['sentiment_score'])}", children=f"{categorize_score(row['sentiment_score'])}"),
+            html.P(
+                className=f"{categorize_score_to_text_class_name(row['sentiment_score'])}",
+                children=f"{row['sentiment_score']}%",
+            ),
+            html.P(
+                className=f"{categorize_score_to_text_class_name(row['sentiment_score'])}",
+                children=f"{categorize_score(row['sentiment_score'])}",
+            ),
             html.P(row['pilar']),
             html.P(row['dimension_sasb']),
             html.P(row['state']),
             html.P(row['state']),
             html.P(row['ds']),
-            html.P(row['data_source'])
+            html.P(row['data_source']),
         ]
     }
     for _, row in reviews_data.iterrows()
@@ -99,6 +104,11 @@ html_data = [
 BENCHMARK_ANALYSIS_LAYOUT = html.Div(
     className="container",
     children=[
+        # Date Picker Section
+        html.Section(
+            className='section pt-3 d-flex justify-content-end',
+            children=[cpt.DatePicker(disabled=False).render()],
+        ),
         # Time trend - Local Industry Analysis Section
         html.Section(
             className="section pt-3",
@@ -226,7 +236,6 @@ BENCHMARK_ANALYSIS_LAYOUT = html.Div(
 def register_callbacks(app):
     @app.callback(
         [
-            Output("overall-time-line-plot", "figure"),
             Output("boxplot-chart", "figure"),
         ],
         [
@@ -242,172 +251,6 @@ def register_callbacks(app):
             & (df["bank_name"].isin(selected_banks))
         ]
 
-        yearly_pilar_line_fig = px.line(
-            filtered_df,
-            x="date",
-            y="sentiment_score",
-            color="bank_name",
-            title=f"Sentiment Score for {selected_year} - {selected_pilar}",
-        )
-        yearly_pilar_line_fig.update_layout(
-            font=dict(family="Roboto"),
-            xaxis=dict(showgrid=True),
-            yaxis=dict(showgrid=True),
-        )
-        total_score_line_fig = px.line(
-            filtered_df,
-            x="date",
-            y="total_sentiment_score",
-            color="bank_name",
-            title=f"Total Sentiment Score for {selected_year}",
-        )
-        total_score_line_fig.update_layout(
-            font=dict(family="Roboto"),
-            xaxis=dict(showgrid=True),
-            yaxis=dict(showgrid=True),
-        )
-        overall_df = (
-            df[df["bank_name"].isin(selected_banks)]
-            .groupby(["bank_name", "date"])
-            .agg({"total_sentiment_score": "mean"})
-            .reset_index()
-        )
-        overall_time_line_fig = px.line(
-            overall_df,
-            x="date",
-            y="total_sentiment_score",
-            color="bank_name",
-        )
-
-        overall_time_line_fig.update_layout(
-            font=dict(family="Roboto"),
-            xaxis=dict(showgrid=True, tickformat="%d-%b", tickangle=-45),
-            yaxis=dict(showgrid=True),
-            updatemenus=[
-                {
-                    "buttons": [
-                        {
-                            "args": [
-                                {
-                                    "xaxis": {
-                                        "range": [
-                                            overall_df["date"].max()
-                                            - pd.Timedelta(days=7),
-                                            overall_df["date"].max(),
-                                        ],
-                                        "tickformat": "%d-%b",
-                                        "tickangle": -45,
-                                    }
-                                }
-                            ],
-                            "label": "1 Week",
-                            "method": "relayout",
-                        },
-                        {
-                            "args": [
-                                {
-                                    "xaxis": {
-                                        "range": [
-                                            overall_df["date"].max()
-                                            - pd.Timedelta(days=30),
-                                            overall_df["date"].max(),
-                                        ],
-                                        "tickformat": "%d-%b",
-                                        "tickangle": -45,
-                                    }
-                                }
-                            ],
-                            "label": "1 Month",
-                            "method": "relayout",
-                        },
-                        {
-                            "args": [
-                                {
-                                    "xaxis": {
-                                        "range": [
-                                            overall_df["date"].max()
-                                            - pd.Timedelta(days=182),
-                                            overall_df["date"].max(),
-                                        ],
-                                        "tickformat": "%b-%Y",
-                                        "tickangle": -45,
-                                    }
-                                }
-                            ],
-                            "label": "6 Months",
-                            "method": "relayout",
-                        },
-                        {
-                            "args": [
-                                {
-                                    "xaxis": {
-                                        "range": [
-                                            overall_df["date"].max()
-                                            - pd.Timedelta(days=365),
-                                            overall_df["date"].max(),
-                                        ],
-                                        "tickformat": "%b-%Y",
-                                        "tickangle": -45,
-                                    }
-                                }
-                            ],
-                            "label": "1 Year",
-                            "method": "relayout",
-                        },
-                        {
-                            "args": [
-                                {
-                                    "xaxis": {
-                                        "range": [
-                                            overall_df["date"].max()
-                                            - pd.Timedelta(days=1095),
-                                            overall_df["date"].max(),
-                                        ],
-                                        "tickformat": "%b-%Y",
-                                        "tickangle": -45,
-                                    }
-                                }
-                            ],
-                            "label": "3 Years",
-                            "method": "relayout",
-                        },
-                        {
-                            "args": [
-                                {
-                                    "xaxis": {
-                                        "range": [
-                                            overall_df["date"].min(),
-                                            overall_df["date"].max(),
-                                        ],
-                                        "tickformat": "%b-%Y",
-                                        "tickangle": -45,
-                                    }
-                                }
-                            ],
-                            "label": "All history",
-                            "method": "relayout",
-                        },
-                    ],
-                    "direction": "left",
-                    "showactive": True,
-                    "x": 0.5,
-                    "xanchor": "center",
-                    "y": 1,
-                    "yanchor": "top",
-                    "type": "buttons",
-                }
-            ],
-            yaxis_title="",
-            xaxis_title="",
-            legend_title="",
-            legend=dict(
-                orientation="h",  # Horizontal orientation
-                yanchor="bottom",  # Anchor the legend to the bottom
-                y=-0.2,  # Place the legend slightly below the chart
-                xanchor="center",  # Center the legend
-                x=0.5,
-            ),
-        )
         boxplot_fig = px.box(
             filtered_df,
             x="bank_name",
@@ -428,11 +271,73 @@ def register_callbacks(app):
             ),
         )
 
-        return (
-            overall_time_line_fig,
-            boxplot_fig,
+        return (boxplot_fig,)
+
+    @app.callback(
+        Output("overall-time-line-plot", "figure"),
+        Input('submit-btn', 'n_clicks'),
+        State('date-picker-range', 'start_date'),
+        State('date-picker-range', 'end_date'),
+        [State(btn_id, 'className') for btn_id in DatePicker.BUTTON_IDS],
+    )
+    def update_line_graph(n_clicks, start_date, end_date, *button_classes):
+        """
+        Updates the line graph based on the selected date range or button.
+        If a date range is selected manually, it uses that range;
+        otherwise, it uses predefined date range buttons.
+        """
+
+        # Convert dates if manually selected
+        if start_date and end_date:
+            start_date = pd.to_datetime(start_date)
+            end_date = pd.to_datetime(end_date)
+        else:
+            # If a predefined button is selected, determine the corresponding date range
+            selected_index = DatePicker.selected_button_index(button_classes)
+            end_date = pd.to_datetime(date.today())
+            start_date = pd.to_datetime(DatePicker.calculate_start_date(selected_index))
+
+        # Aggregate sentiment scores by bank name and date
+        overall_df = (
+            df.groupby(["bank_name", "date"])
+            .agg(total_sentiment_score=("total_sentiment_score", "mean"))
+            .reset_index()
         )
+
+        # Filter the data according to the selected date range
+        overall_df = overall_df[overall_df["date"].between(start_date, end_date)]
+
+        # Create the line plot
+        overall_time_line_fig = px.line(
+            overall_df,
+            x="date",
+            y="total_sentiment_score",
+            color="bank_name",
+        )
+
+        # Update layout properties for clarity and aesthetics
+        overall_time_line_fig.update_layout(
+            font=dict(family="Roboto"),
+            xaxis=dict(showgrid=True, tickformat="%d-%b", tickangle=-45),
+            yaxis=dict(showgrid=True),
+            legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=-0.4,
+                xanchor="center",
+                x=0.5,
+            ),
+            yaxis_title="",
+            xaxis_title="",
+            legend_title="",
+        )
+
+        # Set x-axis date format
+        overall_time_line_fig.update_xaxes(tickformat="%d %b %Y")
+
+        return overall_time_line_fig
 
 
 def register_layout_and_callbacks_benchmark(app):
     register_callbacks(app)
+    register_datepicker_callbacks(app)

--- a/DashMonitor/app/views/layouts/general_analysis.py
+++ b/DashMonitor/app/views/layouts/general_analysis.py
@@ -14,7 +14,11 @@ import dash_bootstrap_components as dbc
 from dash import html
 
 # local imports
-from DashMonitor.app.data.analyzers import GeneralAnalyzer, GeneralComparisonAnalyzer, SASBAnalyzer
+from DashMonitor.app.data.analyzers import (
+    GeneralAnalyzer,
+    GeneralComparisonAnalyzer,
+    SASBAnalyzer,
+)
 from DashMonitor.app.handlers.function_utils import categorize_score
 from DashMonitor.app.handlers import gu
 from DashMonitor.app.views import components as cpt
@@ -24,6 +28,7 @@ from DashMonitor.app.views.configs import (
     INDUSTRY_NAME,
     COUNTRY,
 )
+
 # Import mock data
 from DashMonitor.app.views.layouts.mock_data_sasb_analysis import *
 from DashMonitor.app.views.layouts.mock_data_general_analysis import *
@@ -59,7 +64,10 @@ data_percentile_analysis = [
                 children=[html.B("1"), " out of 1"],
             ),
             html.B(className='text-ssindex-graph-grey mb-0', children="100th"),
-            html.P(className='text-ssindex-graph-grey mb-0', children=f"{rows} out of {rows}"),
+            html.P(
+                className='text-ssindex-graph-grey mb-0',
+                children=f"{rows} out of {rows}",
+            ),
         ]
     },
     {
@@ -91,7 +99,10 @@ data_percentile_analysis = [
                 children=[html.B("1"), " out of 1"],
             ),
             html.B(className='text-ssindex-graph-grey mb-0', children="100th"),
-            html.P(className='text-ssindex-graph-grey mb-0', children=f"{rows} out of {rows}"),
+            html.P(
+                className='text-ssindex-graph-grey mb-0',
+                children=f"{rows} out of {rows}",
+            ),
         ]
     },
     {
@@ -114,11 +125,13 @@ data_percentile_analysis = [
                 children=[html.B("1"), " out of 1"],
             ),
             html.B(className='text-ssindex-graph-grey mb-0', children="100th"),
-            html.P(className='text-ssindex-graph-grey mb-0', children=f"{rows} out of {rows}"),
+            html.P(
+                className='text-ssindex-graph-grey mb-0',
+                children=f"{rows} out of {rows}",
+            ),
         ]
     },
 ]
-    
 
 
 comparison_analyzer = GeneralComparisonAnalyzer(
@@ -151,11 +164,11 @@ fig_hist_general.update_layout(
     legend_title="",
     legend=dict(
         orientation="h",  # Horizontal orientation
-        yanchor="bottom", # Anchor the legend to the bottom
-        y=-0.2,           # Place the legend slightly below the chart
-        xanchor="center", # Center the legend
+        yanchor="bottom",  # Anchor the legend to the bottom
+        y=-0.2,  # Place the legend slightly below the chart
+        xanchor="center",  # Center the legend
         x=0.5,
-    )
+    ),
 )
 
 # Update layout and styling for the text
@@ -164,10 +177,10 @@ fig_hist_general.update_traces(
     textposition='outside',  # Adjust text position (optional)
     textfont=dict(
         family="Manrope",
-        size=14,         # Set font size
-        color="#333B69",   # Set text color
-        weight='bold'    # Make text bold
-    )
+        size=14,  # Set font size
+        color="#333B69",  # Set text color
+        weight='bold',  # Make text bold
+    ),
 )
 
 # ------------------------------------------------------------------------------
@@ -177,14 +190,14 @@ GENERAL_ANALYSIS_LAYOUT = html.Div(
         # Date Picker Section
         html.Section(
             className='section pt-3 d-flex justify-content-end',
-            children=[cpt.DatePicker().render()],
+            children=[cpt.DatePicker(disabled=True).render()],
         ),
         # Company Card Section
         html.Section(
             className='section pt-3',
             children=[
                 cpt.Card(
-                    company_name = COMPANY_NAME,
+                    company_name=COMPANY_NAME,
                     industry=INDUSTRY_NAME,
                     country=COUNTRY,
                     overview=categorize_score(general_score),

--- a/DashMonitor/app/views/layouts/geographic_analysis.py
+++ b/DashMonitor/app/views/layouts/geographic_analysis.py
@@ -20,7 +20,7 @@ from DashMonitor.app.handlers.function_utils import (
     create_gauge_chart,
     create_gauge_chart_ssindex,
     categorize_score_to_bg_class_name,
-    categorize_score_to_text_class_name
+    categorize_score_to_text_class_name,
 )
 from DashMonitor.app.data.analyzers.map_analyzer import MapAnalyzer
 
@@ -54,11 +54,17 @@ data_analyzed_df = analyzer.execute()
 nested_data = [
     [
         html.P(row['review']),
-        html.P(className=f"{categorize_score_to_text_class_name(row['sentiment_score'])}", children=f"{row['sentiment_score']}%"),
-        html.P(className=f"{categorize_score_to_text_class_name(row['sentiment_score'])}", children=f"{categorize_score(row['sentiment_score'])}"),
+        html.P(
+            className=f"{categorize_score_to_text_class_name(row['sentiment_score'])}",
+            children=f"{row['sentiment_score']}%",
+        ),
+        html.P(
+            className=f"{categorize_score_to_text_class_name(row['sentiment_score'])}",
+            children=f"{categorize_score(row['sentiment_score'])}",
+        ),
         html.P(row['state']),
         html.P(row['ds']),
-        html.P(row['data_source'])
+        html.P(row['data_source']),
     ]
     for _, row in reviews_data.iterrows()
 ]
@@ -81,7 +87,9 @@ html_data = [
             html.P(row['state']),
             html.Div(
                 className=f"{categorize_score_to_bg_class_name(row['sentiment_score'])} w-100 h-100 border rounded",
-                children=html.B(className='text-white', children=f"{round(row['sentiment_score'])}"),
+                children=html.B(
+                    className='text-white', children=f"{round(row['sentiment_score'])}"
+                ),
             ),
             html.Div(
                 className="bg-ssindex-excellent w-100 h-100 border rounded",
@@ -100,7 +108,7 @@ GEOGRAPHIC_ANALYSIS_LAYOUT = html.Div(
         # Date Picker Secion
         html.Section(
             className='section pt-3 d-flex justify-content-end',
-            children=[cpt.DatePicker().render()],
+            children=[cpt.DatePicker(disabled=True).render()],
         ),
         html.Section(
             className="section pt-5",

--- a/DashMonitor/app/views/layouts/sasb_analysis.py
+++ b/DashMonitor/app/views/layouts/sasb_analysis.py
@@ -289,7 +289,7 @@ SASB_ANALYSIS_LAYOUT = html.Div(
         # Date Picker Section
         html.Section(
             className='section pt-3 d-flex justify-content-end',
-            children=[cpt.DatePicker().render()],
+            children=[cpt.DatePicker(disabled=True).render()],
         ),
         # Company Card Section
         html.Section(


### PR DESCRIPTION
### Summary
Se añadió al componente de DatePicker el prop disabled, que cuando es True deshabilita el botón para poder filtrar. Se colocó el DatePicker con prop disabled en las pestañas  general geographic y sasb. En la pestaña de benchmark/timetrend se colocó este DatePicker como True y se conecto el callback de esta función con el gráfico de timetrend.

### Files changed
M       DashMonitor/app/views/components/date_picker/callbacks.py
M       DashMonitor/app/views/components/date_picker/date_picker.py
M       DashMonitor/app/views/layouts/benchmark_analysis.py
M       DashMonitor/app/views/layouts/general_analysis.py
M       DashMonitor/app/views/layouts/geographic_analysis.py
M       DashMonitor/app/views/layouts/sasb_analysis.py
### Source branch
`dev`
