### PR TITLE
Decompose table component

### DIFF
--- a/DashMonitor/app/views/components/table/table.py
+++ b/DashMonitor/app/views/components/table/table.py
@@ -76,122 +76,10 @@ class Table(BaseComponent):
         self.class_name_rows = class_name_rows
         self.class_name_div = class_name_div
 
-    def _render_nested_table(
-        self, nested_data: List[List[str]], nested_headers: List[str], index: int
-    ) -> html.Tr:
-        """
-        Renders a nested table inside a collapsible row.
-
-        Parameters
-        ----------
-        nested_data : List[List[str]]
-            A list of lists, where each inner list represents a row of values for the nested table.
-        nested_headers : List[str]
-            A list of strings representing the headers to display in the nested table.
-        index : int
-            The index of the row. Used to create unique class names for collapsibility
-            and to differentiate nested tables in the DOM.
-        """
-        rows = [
-            html.Tr(
-                children=[
-                    html.Td(
-                        className="text-center align-middle fs-7",
-                        children=val,
-                    )
-                    for val in nested_row
-                ]
-            )
-            for nested_row in nested_data
-        ]
-        return html.Tr(
-            children=html.Td(
-                className='table-ssindex-nested-table-background text-center rounded-3 shadow-none',
-                colSpan=len(self.headers),
-                children=[
-                    html.Div(
-                        className=f'nestedTable{index}',
-                        children=html.Table(
-                            className='table table-borderless table-responsive table-ssindex-nested-table-background rounded',
-                            children=[
-                                TableHeader(
-                                    headers=nested_headers,
-                                    thead_class_name='text-center table-white align-middle',
-                                    th_class_name='text-center table-white fs-7',
-                                ).render(),
-                                TableBody(
-                                    rows=rows,
-                                ).render(),
-                            ],
-                        ),
-                    )
-                ],
-            ),
-            className=f'collapse nestedTable{index} {self.class_name_rows}',
-        )
-
-    def _render_main_row(self, row: Dict[str, Any], index: int) -> html.Tr:
-        """
-        Renders a single row of the main table and adds collapsibility if nested data is present.
-
-        Parameters
-        ----------
-        row : Dict[str, Any]
-            A dictionary representing the row data. It must contain a key 'data' with a list of values
-            for the main table row. If the row has nested data, it may include:
-            - 'nested_data': List of lists, where each inner list represents a row of nested table data.
-            - 'nested_headers': List of strings for nested table headers (optional).
-        index : int
-            The index of the row. Used to associate the main row with its corresponding nested table
-            for collapsibility.
-        """
-        return html.Tr(
-            className=self.class_name_rows,
-            role='button' if 'nested_data' in row else None,
-            children=[html.Td(val) for val in row['data']],
-            **(
-                {
-                    'data-bs-toggle': 'collapse',
-                    'data-bs-target': f'.nestedTable{index}',
-                }
-                if 'nested_data' in row
-                else {}
-            ),
-        )
-
-    def _render_rows(self) -> List[html.Tr]:
-        """
-        Renders all rows for the main table, including nested tables if present.
-
-        This method iterates through the data provided to the table and generates a list of Dash `html.Tr` components, representing each row in the table.
-        If a row contains nested data, it will generate both the main row and a collapsible nested table.
-        """
-        rows = []
-        # Loop through each row of data
-        for index, row in enumerate(self.data):
-            # Create the main row
-            main_row = self._render_main_row(row, index)
-            # Get the nested headers if present
-            nested_headers = row.get('nested_headers', [])
-            # Append the main row and the nested table if present
-            rows.extend(
-                [
-                    main_row,
-                    self._render_nested_table(
-                        row['nested_data'], nested_headers, index
-                    ),
-                ]
-                if 'nested_data' in row
-                else [main_row]
-            )
-
-        return rows
-
     def render(self) -> html.Table:
         '''
         Generates the Dash Component for the table.
         '''
-        rows = self._render_rows()
         return html.Div(
             className=self.class_name_div,
             children=[
@@ -205,7 +93,7 @@ class Table(BaseComponent):
                             th_class_name=self.class_name_headers,
                         ).render(),
                         TableBody(
-                            rows=rows, class_name="align-middle text-center"
+                            data=self.data, class_name="align-middle text-center", class_name_rows=self.class_name_rows
                         ).render(),
                         TableFooter(self.footer_data).render(),
                     ],

--- a/DashMonitor/app/views/components/table/table.py
+++ b/DashMonitor/app/views/components/table/table.py
@@ -93,7 +93,9 @@ class Table(BaseComponent):
                             th_class_name=self.class_name_headers,
                         ).render(),
                         TableBody(
-                            data=self.data, class_name="align-middle text-center", class_name_rows=self.class_name_rows
+                            data=self.data,
+                            class_name="align-middle text-center",
+                            class_name_rows=self.class_name_rows,
                         ).render(),
                         TableFooter(self.footer_data).render(),
                     ],

--- a/DashMonitor/app/views/components/table/table_body.py
+++ b/DashMonitor/app/views/components/table/table_body.py
@@ -5,6 +5,8 @@ Table Body Definition
 from typing import List, Optional
 from DashMonitor.app.views.components.base_component import BaseComponent
 from dash import html
+from typing import List, Dict, Any, Optional
+from DashMonitor.app.views.components.table.table_header import TableHeader
 
 
 class TableBody(BaseComponent):
@@ -12,15 +14,128 @@ class TableBody(BaseComponent):
     Table Body component. Generates a tbody for a table.
     '''
 
-    def __init__(self, rows: List[html.Tr] | html.Tr, class_name: Optional[str] = ''):
-        self.rows = rows
+    def __init__(self, data: List[html.Tr] | html.Tr, class_name: Optional[str] = '', class_name_rows: Optional[str] = ''):
+        self.data = data
         self.class_name = class_name
+        self.class_name_rows = class_name_rows
+
+    def _render_nested_table(
+        self, nested_data: List[List[str]], nested_headers: List[str], index: int
+    ) -> html.Tr:
+        """
+        Renders a nested table inside a collapsible row.
+
+        Parameters
+        ----------
+        nested_data : List[List[str]]
+            A list of lists, where each inner list represents a row of values for the nested table.
+        nested_headers : List[str]
+            A list of strings representing the headers to display in the nested table.
+        index : int
+            The index of the row. Used to create unique class names for collapsibility
+            and to differentiate nested tables in the DOM.
+        """
+        rows = [
+            html.Tr(
+                children=[
+                    html.Td(
+                        className="text-center align-middle fs-7",
+                        children=val,
+                    )
+                    for val in nested_row
+                ]
+            )
+            for nested_row in nested_data
+        ]
+        return html.Tr(
+            children=html.Td(
+                className='table-ssindex-nested-table-background text-center rounded-3 shadow-none',
+                colSpan=100,
+                children=[
+                    html.Div(
+                        className=f'nestedTable{index}',
+                        children=html.Table(
+                            className='table table-borderless table-responsive table-ssindex-nested-table-background rounded',
+                            children=[
+                                TableHeader(
+                                    headers=nested_headers,
+                                    thead_class_name='text-center table-white align-middle',
+                                    th_class_name='text-center table-white fs-7',
+                                ).render(),
+                                html.Tbody(
+                                    children=rows
+                                )
+                            ],
+                        ),
+                    )
+                ],
+            ),
+            className=f'collapse nestedTable{index} {self.class_name_rows}',
+        )
+
+    def _render_main_row(self, row: Dict[str, Any], index: int) -> html.Tr:
+        """
+        Renders a single row of the main table and adds collapsibility if nested data is present.
+
+        Parameters
+        ----------
+        row : Dict[str, Any]
+            A dictionary representing the row data. It must contain a key 'data' with a list of values
+            for the main table row. If the row has nested data, it may include:
+            - 'nested_data': List of lists, where each inner list represents a row of nested table data.
+            - 'nested_headers': List of strings for nested table headers (optional).
+        index : int
+            The index of the row. Used to associate the main row with its corresponding nested table
+            for collapsibility.
+        """
+        return html.Tr(
+            className=self.class_name_rows,
+            role='button' if 'nested_data' in row else None,
+            children=[html.Td(val) for val in row['data']],
+            **(
+                {
+                    'data-bs-toggle': 'collapse',
+                    'data-bs-target': f'.nestedTable{index}',
+                }
+                if 'nested_data' in row
+                else {}
+            ),
+        )
+
+    def _render_rows(self) -> List[html.Tr]:
+        """
+        Renders all rows for the main table, including nested tables if present.
+
+        This method iterates through the data provided to the table and generates a list of Dash `html.Tr` components, representing each row in the table.
+        If a row contains nested data, it will generate both the main row and a collapsible nested table.
+        """
+        rows = []
+        # Loop through each row of data
+        for index, row in enumerate(self.data):
+            # Create the main row
+            main_row = self._render_main_row(row, index)
+            # Get the nested headers if present
+            nested_headers = row.get('nested_headers', [])
+            # Append the main row and the nested table if present
+            rows.extend(
+                [
+                    main_row,
+                    self._render_nested_table(
+                        row['nested_data'], nested_headers, index
+                    ),
+                ]
+                if 'nested_data' in row
+                else [main_row]
+            )
+
+        return rows
 
     def render(self) -> html.Tbody:
         """
         Renders the table body.
         """
+        rows = self._render_rows()
         return html.Tbody(
             className=self.class_name,
-            children=self.rows,
+            children=rows,
         )

--- a/DashMonitor/app/views/components/table/table_body.py
+++ b/DashMonitor/app/views/components/table/table_body.py
@@ -1,22 +1,31 @@
-'''
-Table Body Definition
-'''
-
-from typing import List, Optional
+from typing import List, Dict, Any, Optional
 from DashMonitor.app.views.components.base_component import BaseComponent
 from dash import html
-from typing import List, Dict, Any, Optional
 from DashMonitor.app.views.components.table.table_header import TableHeader
+from DashMonitor.app.views.components.table.table_row import (
+    TableRow,
+)  # Import the new component
 
 
 class TableBody(BaseComponent):
-    '''
+    """
     Table Body component. Generates a tbody for a table.
-    '''
+
+    Parameters
+    ----------
+    data : List[Dict[str, Any]]
+        List of dictionaries where each dictionary represents a row in the table.
+        Each dictionary must contain a key 'data' with a list of values corresponding to the main table's row data.
+        Optionally, a dictionary can contain:
+        - 'nested_headers': List of strings representing headers for the nested table (if present).
+          Example: 'nested_headers': ['Nested Header 1', 'Nested Header 2']
+        - 'nested_data': List of lists, where each inner list represents a row of data for the nested table.
+          Example: 'nested_data': [['Nested Value 1', 'Nested Value 2']]
+    """
 
     def __init__(
         self,
-        data: List[html.Tr] | html.Tr,
+        data: List[Dict[str, Any]],
         class_name: Optional[str] = '',
         class_name_rows: Optional[str] = '',
     ):
@@ -24,113 +33,16 @@ class TableBody(BaseComponent):
         self.class_name = class_name
         self.class_name_rows = class_name_rows
 
-    def _render_nested_table(
-        self, nested_data: List[List[str]], nested_headers: List[str], index: int
-    ) -> html.Tr:
-        """
-        Renders a nested table inside a collapsible row.
-
-        Parameters
-        ----------
-        nested_data : List[List[str]]
-            A list of lists, where each inner list represents a row of values for the nested table.
-        nested_headers : List[str]
-            A list of strings representing the headers to display in the nested table.
-        index : int
-            The index of the row. Used to create unique class names for collapsibility
-            and to differentiate nested tables in the DOM.
-        """
-        rows = [
-            html.Tr(
-                children=[
-                    html.Td(
-                        className="text-center align-middle fs-7",
-                        children=val,
-                    )
-                    for val in nested_row
-                ]
-            )
-            for nested_row in nested_data
-        ]
-        return html.Tr(
-            children=html.Td(
-                className='table-ssindex-nested-table-background text-center rounded-3 shadow-none',
-                colSpan=100,
-                children=[
-                    html.Div(
-                        className=f'nestedTable{index}',
-                        children=html.Table(
-                            className='table table-borderless table-responsive table-ssindex-nested-table-background rounded',
-                            children=[
-                                TableHeader(
-                                    headers=nested_headers,
-                                    thead_class_name='text-center table-white align-middle',
-                                    th_class_name='text-center table-white fs-7',
-                                ).render(),
-                                html.Tbody(children=rows),
-                            ],
-                        ),
-                    )
-                ],
-            ),
-            className=f'collapse nestedTable{index} {self.class_name_rows}',
-        )
-
-    def _render_main_row(self, row: Dict[str, Any], index: int) -> html.Tr:
-        """
-        Renders a single row of the main table and adds collapsibility if nested data is present.
-
-        Parameters
-        ----------
-        row : Dict[str, Any]
-            A dictionary representing the row data. It must contain a key 'data' with a list of values
-            for the main table row. If the row has nested data, it may include:
-            - 'nested_data': List of lists, where each inner list represents a row of nested table data.
-            - 'nested_headers': List of strings for nested table headers (optional).
-        index : int
-            The index of the row. Used to associate the main row with its corresponding nested table
-            for collapsibility.
-        """
-        return html.Tr(
-            className=self.class_name_rows,
-            role='button' if 'nested_data' in row else None,
-            children=[html.Td(val) for val in row['data']],
-            **(
-                {
-                    'data-bs-toggle': 'collapse',
-                    'data-bs-target': f'.nestedTable{index}',
-                }
-                if 'nested_data' in row
-                else {}
-            ),
-        )
-
     def _render_rows(self) -> List[html.Tr]:
         """
         Renders all rows for the main table, including nested tables if present.
-
-        This method iterates through the data provided to the table and generates a list of Dash `html.Tr` components, representing each row in the table.
-        If a row contains nested data, it will generate both the main row and a collapsible nested table.
         """
         rows = []
-        # Loop through each row of data
         for index, row in enumerate(self.data):
-            # Create the main row
-            main_row = self._render_main_row(row, index)
-            # Get the nested headers if present
-            nested_headers = row.get('nested_headers', [])
-            # Append the main row and the nested table if present
-            rows.extend(
-                [
-                    main_row,
-                    self._render_nested_table(
-                        row['nested_data'], nested_headers, index
-                    ),
-                ]
-                if 'nested_data' in row
-                else [main_row]
+            table_row = TableRow(
+                row_data=row, index=index, class_name_rows=self.class_name_rows
             )
-
+            rows.extend(table_row.render())
         return rows
 
     def render(self) -> html.Tbody:

--- a/DashMonitor/app/views/components/table/table_body.py
+++ b/DashMonitor/app/views/components/table/table_body.py
@@ -14,7 +14,12 @@ class TableBody(BaseComponent):
     Table Body component. Generates a tbody for a table.
     '''
 
-    def __init__(self, data: List[html.Tr] | html.Tr, class_name: Optional[str] = '', class_name_rows: Optional[str] = ''):
+    def __init__(
+        self,
+        data: List[html.Tr] | html.Tr,
+        class_name: Optional[str] = '',
+        class_name_rows: Optional[str] = '',
+    ):
         self.data = data
         self.class_name = class_name
         self.class_name_rows = class_name_rows
@@ -62,9 +67,7 @@ class TableBody(BaseComponent):
                                     thead_class_name='text-center table-white align-middle',
                                     th_class_name='text-center table-white fs-7',
                                 ).render(),
-                                html.Tbody(
-                                    children=rows
-                                )
+                                html.Tbody(children=rows),
                             ],
                         ),
                     )

--- a/DashMonitor/app/views/components/table/table_row.py
+++ b/DashMonitor/app/views/components/table/table_row.py
@@ -17,45 +17,50 @@ class TableRow:
         Custom class name to apply to the row. Defaults to an empty string.
     """
 
+    NESTED_TABLE_CONTAINER_TD_CLASS_NAME = (
+        'table-ssindex-nested-table-background text-center rounded-3 shadow-none'
+    )
+    NESTED_TABLE_CLASS_NAME = 'table table-borderless table-responsive table-ssindex-nested-table-background rounded'
+    NESTED_TABLE_TH_CLASS_NAME = 'text-center table-white fs-7'
+    NESTED_TABLE_TD_CLASS_NAME = 'text-center align-middle fs-7'
+
     def __init__(self, row_data: Dict[str, Any], index: int, class_name_rows: str = ''):
         self.row_data = row_data
         self.index = index
         self.class_name_rows = class_name_rows
+        self.nested_data = row_data.get('nested_data', [])
+        self.nested_headers = row_data.get('nested_headers', [])
 
     def _render_nested_table(self) -> html.Tr:
         """
         Renders a nested table inside a collapsible row.
         """
-        nested_data = self.row_data.get('nested_data', [])
-        nested_headers = self.row_data.get('nested_headers', [])
-
         rows = [
             html.Tr(
                 children=[
                     html.Td(
-                        className="text-center align-middle fs-7",
+                        className=self.NESTED_TABLE_TD_CLASS_NAME,
                         children=val,
                     )
                     for val in nested_row
                 ]
             )
-            for nested_row in nested_data
+            for nested_row in self.nested_data
         ]
 
         return html.Tr(
             children=html.Td(
-                className='table-ssindex-nested-table-background text-center rounded-3 shadow-none',
+                className=self.NESTED_TABLE_CONTAINER_TD_CLASS_NAME,
                 colSpan=100,
                 children=[
                     html.Div(
                         className=f'nestedTable{self.index}',
                         children=html.Table(
-                            className='table table-borderless table-responsive table-ssindex-nested-table-background rounded',
+                            className=self.NESTED_TABLE_CLASS_NAME,
                             children=[
                                 TableHeader(
-                                    headers=nested_headers,
-                                    thead_class_name='text-center table-white align-middle',
-                                    th_class_name='text-center table-white fs-7',
+                                    headers=self.nested_headers,
+                                    th_class_name=self.NESTED_TABLE_TH_CLASS_NAME,
                                 ).render(),
                                 html.Tbody(children=rows),
                             ],
@@ -72,14 +77,14 @@ class TableRow:
         """
         return html.Tr(
             className=self.class_name_rows,
-            role='button' if 'nested_data' in self.row_data else None,
+            role='button' if self.nested_data else None,
             children=[html.Td(val) for val in self.row_data['data']],
             **(
                 {
                     'data-bs-toggle': 'collapse',
                     'data-bs-target': f'.nestedTable{self.index}',
                 }
-                if 'nested_data' in self.row_data
+                if self.nested_data
                 else {}
             ),
         )

--- a/DashMonitor/app/views/components/table/table_row.py
+++ b/DashMonitor/app/views/components/table/table_row.py
@@ -1,0 +1,94 @@
+from dash import html
+from typing import Dict, Any, List
+from DashMonitor.app.views.components.table.table_header import TableHeader
+
+
+class TableRow:
+    """
+    TableRow component. Generates either a main or nested table row.
+
+    Parameters
+    ----------
+    row_data : Dict[str, Any]
+        Dictionary containing the row data.
+    index : int
+        Index of the row.
+    class_name_rows : str, default ''
+        Custom class name to apply to the row. Defaults to an empty string.
+    """
+
+    def __init__(self, row_data: Dict[str, Any], index: int, class_name_rows: str = ''):
+        self.row_data = row_data
+        self.index = index
+        self.class_name_rows = class_name_rows
+
+    def _render_nested_table(self) -> html.Tr:
+        """
+        Renders a nested table inside a collapsible row.
+        """
+        nested_data = self.row_data.get('nested_data', [])
+        nested_headers = self.row_data.get('nested_headers', [])
+
+        rows = [
+            html.Tr(
+                children=[
+                    html.Td(
+                        className="text-center align-middle fs-7",
+                        children=val,
+                    )
+                    for val in nested_row
+                ]
+            )
+            for nested_row in nested_data
+        ]
+
+        return html.Tr(
+            children=html.Td(
+                className='table-ssindex-nested-table-background text-center rounded-3 shadow-none',
+                colSpan=100,
+                children=[
+                    html.Div(
+                        className=f'nestedTable{self.index}',
+                        children=html.Table(
+                            className='table table-borderless table-responsive table-ssindex-nested-table-background rounded',
+                            children=[
+                                TableHeader(
+                                    headers=nested_headers,
+                                    thead_class_name='text-center table-white align-middle',
+                                    th_class_name='text-center table-white fs-7',
+                                ).render(),
+                                html.Tbody(children=rows),
+                            ],
+                        ),
+                    )
+                ],
+            ),
+            className=f'collapse nestedTable{self.index} {self.class_name_rows}',
+        )
+
+    def _render_main_row(self) -> html.Tr:
+        """
+        Renders a single row of the main table and adds collapsibility if nested data is present.
+        """
+        return html.Tr(
+            className=self.class_name_rows,
+            role='button' if 'nested_data' in self.row_data else None,
+            children=[html.Td(val) for val in self.row_data['data']],
+            **(
+                {
+                    'data-bs-toggle': 'collapse',
+                    'data-bs-target': f'.nestedTable{self.index}',
+                }
+                if 'nested_data' in self.row_data
+                else {}
+            ),
+        )
+
+    def render(self) -> List[html.Tr]:
+        """
+        Renders the table row(s). Returns the main row and, if present, the nested table row.
+        """
+        rows = [self._render_main_row()]
+        if 'nested_data' in self.row_data:
+            rows.append(self._render_nested_table())
+        return rows


### PR DESCRIPTION
### Summary
Se movieron los métodos de table hacia table_body y table_body, haciendo más coherente el componente de table y desacoplando las distintas e implementaciones de las distintas partes de la tabla. Esto mejoró el radon maintanibility index y sigue más el lineamiento de Single Responsability

### Files changed
M       DashMonitor/app/views/components/table/table.py
M       DashMonitor/app/views/components/table/table_body.py
A       DashMonitor/app/views/components/table/table_row.py
### Source branch
`dev`
